### PR TITLE
fix: fix debugger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,19 @@
 ARG NODE_VERSION=20.19.0
-FROM node:${NODE_VERSION}-bookworm-slim AS base
+FROM node:${NODE_VERSION}-alpine AS base
 WORKDIR /debugger
 
 FROM base AS builder
-RUN apt-get update && apt-get install -y make python3 g++ git
+RUN apk update && apk add make python3 g++ git
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile --production
 
 FROM base AS final
+RUN apk update && apk add bash mc
 RUN ln -s /codefresh/volume/cf_export /bin/cf_export
-
 # purpose of security
 RUN npm uninstall -g --logs-max=0 corepack npm
-USER node
-
 ENV PS1='\[\033[01;32m\]\u@codefresh\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
 ENV LS_COLORS='rs=0:di=01;34:ln=01;36:mh=00:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:mi=00:su=37;41:sg=30;43:ca=30;41:tw=30;42:ow=34;42:st=37;44:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arc=01;31:*.arj=01;31:*.taz=01;31:*.lha=01;31:*.lz4=01;31:*.lzh=01;31:*.lzma=01;31:*.tlz=01;31:*.txz=01;31:*.tzo=01;31:*.t7z=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.dz=01;31:*.gz=01;31:*.lrz=01;31:*.lz=01;31:*.lzo=01;31:*.xz=01;31:*.zst=01;31:*.tzst=01;31:*.bz2=01;31:*.bz=01;31:*.tbz=01;31:*.tbz2=01;31:*.tz=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.war=01;31:*.ear=01;31:*.sar=01;31:*.rar=01;31:*.alz=01;31:*.ace=01;31:*.zoo=01;31:*.cpio=01;31:*.7z=01;31:*.rz=01;31:*.cab=01;31:*.wim=01;31:*.swm=01;31:*.dwm=01;31:*.esd=01;31:*.jpg=01;35:*.jpeg=01;35:*.mjpg=01;35:*.mjpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.svg=01;35:*.svgz=01;35:*.mng=01;35:*.pcx=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.m2v=01;35:*.mkv=01;35:*.webm=01;35:*.ogm=01;35:*.mp4=01;35:*.m4v=01;35:*.mp4v=01;35:*.vob=01;35:*.qt=01;35:*.nuv=01;35:*.wmv=01;35:*.asf=01;35:*.rm=01;35:*.rmvb=01;35:*.flc=01;35:*.avi=01;35:*.fli=01;35:*.flv=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.yuv=01;35:*.cgm=01;35:*.emf=01;35:*.ogv=01;35:*.ogx=01;35:*.aac=00;36:*.au=00;36:*.flac=00;36:*.m4a=00;36:*.mid=00;36:*.midi=00;36:*.mka=00;36:*.mp3=00;36:*.mpc=00;36:*.ogg=00;36:*.ra=00;36:*.wav=00;36:*.oga=00;36:*.opus=00;36:*.spx=00;36:*.xspf=00;36:'
-
-COPY --from=builder --chown=node:node /debugger/node_modules node_modules
-COPY --chown=node:node src src
-
+COPY --from=builder /debugger/node_modules node_modules
+COPY src src
 CMD ["node", "/debugger/src/app.js"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cf-debugger",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "index.js",
   "license": "MIT",
   "resolutions": {
@@ -12,5 +12,6 @@
   },
   "engines": {
     "node": "20.19.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/.bashrc
+++ b/src/.bashrc
@@ -1,0 +1,3 @@
+which resize > /dev/null \
+  && eval $(resize) \
+  && echo -e "\r\e[1;33m💡 Tip: Execute \"\e[1;32meval \$(resize)\e[1;33m\" to adjust the terminal size to match the current window dimensions.\e[m"

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,15 @@
+const { resolve } = require('path');
 const pty = require('node-pty');
 const Resizer = require('./Resizer.js');
 
+const bashrcPath = resolve(__dirname, './.bashrc');
+
 let exit = false;
 
-const shell = pty.spawn('/bin/bash', [], {
+const shell = pty.spawn('bash', [
+    '--init-file',
+    bashrcPath,
+], {
     name: 'xterm-color',
     cwd: process.env.PWD,
     env: process.env


### PR DESCRIPTION
## What

This fixes debugger by partially reverting changes from #24:
* `bash` is required as it is an entry-point for the spawned shell;
* removal of `mc` is a breaking change;
* changing base image is a breaking change as it have different set of bound tools, so the existing customer script may broke.

This also resizes terminal to fit window during initial launch; and provides tip on how to resize it again if needed.

## Notes
<!-- Add any notes here -->

## Labels

Assign the following labels to the PR:

`security` - to trigger image scanning in CI build

## PR Comments

Add the following comments to the PR:

`/e2e` - to trigger E2E build
